### PR TITLE
Add support for configuring a WriteFreely server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
 
 ## What?
 
-Publish notes to https://write.as.
+Publish notes to https://write.as or a self-hosted [WriteFreely](https://writefreely.org/) instance.
 
 ## Disclosure
 
 1. This plugin publishes content using the Internet
-2. This plugin requires an account with https://write.as
+2. This plugin requires an account with https://write.as or a self-hosted
+   [WriteFreely](https://writefreely.org/)
 
 ## How?
 
-1. Set your username and password in the plugin settings
+1. Set your username, password, and optionally your WriteFreely instance URL 
+   in the plugin settings
 2. Add `writeas_collection` into your frontmatter, set it to a collection/blog
    that you own (this **must** be set)
+   - If you're using a self-hosted WriteFreely instance in single-user mode, 
+     the `writeas_collection` value must be equal to your username
 3. Run `Publish/update` (or use alt+shift+p)
 4. The plugin will add the ID and the post URL to your frontmatter. Subsequent
    publish commands will then update the same post.

--- a/src/Writeas.ts
+++ b/src/Writeas.ts
@@ -7,16 +7,18 @@ export class WriteasClient {
 
     user: string;
     pass: string;
+    baseUrl: string;
     token: string;
 
-    constructor(user: string, pass: string) {
+    constructor(user: string, pass: string, baseUrl: string) {
         this.user = user;
         this.pass = pass;
+        this.baseUrl = baseUrl;
     }
 
     login() {
         return requestUrl({
-            url: "https://write.as/api/auth/login",
+            url: `${this.baseUrl}/api/auth/login`,
             body: JSON.stringify({ alias: this.user, pass: this.pass }),
             method: "POST",
             headers: {
@@ -33,7 +35,7 @@ export class WriteasClient {
 
     getCollections() {
         return requestUrl({
-            url: "https://write.as/api/me/collections",
+            url: `${this.baseUrl}/api/me/collections`,
             method: "GET",
             headers: {
                 "Content-Type": 'application/json',
@@ -50,7 +52,7 @@ export class WriteasClient {
 
     getPost(post_id: string) {
         return requestUrl({
-            url: `https://write.as/api/posts/${post_id}`,
+            url: `${this.baseUrl}/api/posts/${post_id}`,
             method: "GET",
             headers: {
                 "Content-Type": 'application/json',
@@ -67,7 +69,7 @@ export class WriteasClient {
 
     moveToCollection(collection: string, post_id: string) {
         return requestUrl({
-            url: `https://write.as/api/collections/${collection}/collect`,
+            url: `${this.baseUrl}/api/collections/${collection}/collect`,
             body: JSON.stringify([{ id: post_id }]),
             method: "POST",
             headers: {
@@ -85,7 +87,7 @@ export class WriteasClient {
 
     publishPost(body: any, collection: string) {
         return requestUrl({
-            url: `https://write.as/api/collections/${collection}/posts`,
+            url: `${this.baseUrl}/api/collections/${collection}/posts`,
             body: JSON.stringify(body),
             method: "POST",
             headers: {
@@ -104,7 +106,7 @@ export class WriteasClient {
 
     updatePost(body: any, post_id: string) {
         return requestUrl({
-            url: `https://write.as/api/posts/${post_id}`,
+            url: `${this.baseUrl}/api/posts/${post_id}`,
             body: JSON.stringify(body),
             method: "POST",
             headers: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,11 +4,13 @@ import { WriteasClient } from './Writeas';
 interface WriteasPluginSettings {
 	writeasUser: string;
 	writeasPassword: string;
+	writeasServer: string;
 }
 
 const DEFAULT_SETTINGS: WriteasPluginSettings = {
 	writeasUser: 'default',
-	writeasPassword: 'default'
+	writeasPassword: 'default',
+	writeasServer: 'https://write.as'
 }
 
 const COLL_KEY = 'writeas_collection';
@@ -43,7 +45,7 @@ export default class WriteasPlugin extends Plugin {
 
 
 	async handleFile(file: TFile) {
-		let c = new WriteasClient(this.settings.writeasUser, this.settings.writeasPassword);
+		let c = new WriteasClient(this.settings.writeasUser, this.settings.writeasPassword, this.settings.writeasServer);
 		this.app.vault.cachedRead(file).then(async lines => {
 			var content = this.app.metadataCache.getFileCache(file);
 			if (content?.frontmatter && content.frontmatter[COLL_KEY]) {
@@ -122,6 +124,7 @@ class SettingTab extends PluginSettingTab {
 					this.plugin.settings.writeasUser = value;
 					await this.plugin.saveSettings();
 				}));
+
 		new Setting(containerEl)
 			.setName('Writeas Password')
 			.setDesc('')
@@ -130,6 +133,17 @@ class SettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.writeasPassword)
 				.onChange(async (value) => {
 					this.plugin.settings.writeasPassword = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Writeas Server')
+			.setDesc('')
+			.addText(text => text
+				.setPlaceholder('Enter the URL of your WriteFreely server')
+				.setValue(this.plugin.settings.writeasServer)
+				.onChange(async (value) => {
+					this.plugin.settings.writeasServer = value;
 					await this.plugin.saveSettings();
 				}));
 	}


### PR DESCRIPTION
Added a user-configurable setting for WriteFreely Server URL, which allows users to publish posts to a self-hosted instance.

Fixes #1 